### PR TITLE
Fix logic to account for existing_event being nil

### DIFF
--- a/app/graphql/mutations/create_event.rb
+++ b/app/graphql/mutations/create_event.rb
@@ -18,19 +18,22 @@ class Mutations::CreateEvent < Mutations::BaseMutation
 
   def resolve(name:, date:, image:, buy_tickets_url:, time:, venue_name:, city:, state:, address:, longitude:, latitude:, ticketmaster_id:, user_id:)
     existing_event = Event.find_by(name: name, date: date, city:city)
-    existing_user = UserEvent.find_by(user_id: user_id, event_id: existing_event.id)
+    # existing_user = UserEvent.find_by(user_id: user_id, event_id: existing_event.id)
 
-    if existing_event && existing_user
+    if existing_event 
+      existing_user = UserEvent.find_by(user_id: user_id, event_id: existing_event.id)
+      if existing_user
       {
         event: existing_event,
         errors: []
       }
-    elsif existing_event 
+      else 
       UserEvent.create(user_id: user_id, event_id: existing_event.id)
       {
         event: existing_event,
         errors: []
       }
+      end 
     elsif existing_event == nil
       event = Event.create(name: name, date: date, image: image, buy_tickets_url: buy_tickets_url, time: time, venue_name: venue_name, city: city, state: state, address: address, longitude: longitude, latitude: latitude, ticketmaster_id: ticketmaster_id)
       UserEvent.create(user_id: user_id, event_id: event.id)


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):
## Problem/feature
_What problem are you trying to solve?_
there was a flaw in our logic (we didn't account for when there isn't an existing_event, in which case existing_user = UserEvent.find_by(user_id: user_id, event_id: existing_event.id) produces an error because existing_event is nil so can't do nil.id
## Solution
_How did you solve the problem?_
Restructured our conditionals 
## Other changes (e.g. bug fixes, UI tweaks, small refactors)
## Checklist
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
